### PR TITLE
Support for actions mods in the development server

### DIFF
--- a/tools/mods-dev-server/cli.js
+++ b/tools/mods-dev-server/cli.js
@@ -48,7 +48,9 @@ if (require.main === module) {
                         // @ts-ignore
                         path: argv.path,
                         // @ts-ignore
-                        open: argv.open
+                        open: argv.open,
+                        // @ts-ignore
+                        allowProjectRoot: argv.allowProjectRoot
                     });
                 }
             )
@@ -68,6 +70,12 @@ if (require.main === module) {
                 describe: "Whether or not to open a browser on launch.",
                 boolean: true,
                 default: defaultSettings.open
+            })
+            .option("allow-project-root", {
+                describe:
+                    "Whether or not the server should expose an endpoint for retrieving the path to the project root.",
+                boolean: true,
+                default: defaultSettings.allowProjectRoot
             })
             .boolean(["open"])
             .version(packageJson.version)

--- a/tools/mods-dev-server/cli.js
+++ b/tools/mods-dev-server/cli.js
@@ -73,7 +73,7 @@ if (require.main === module) {
             })
             .option("allow-project-root", {
                 describe:
-                    "Whether or not the server should expose an endpoint for retrieving the path to the project root.",
+                    "Whether or not the server should expose an endpoint at /spotfire/modProjectRoot for retrieving the path to the project root.",
                 boolean: true,
                 default: defaultSettings.allowProjectRoot
             })

--- a/tools/mods-dev-server/server.d.ts
+++ b/tools/mods-dev-server/server.d.ts
@@ -13,7 +13,7 @@ export interface ServerSettings {
     /** Whether or not to open a browser. Defaults to true. */
     open?: boolean;
 
-    /** If the server should expose the modProjectRoot endpoint. */
+    /** If the server should expose the spotfire/modProjectRoot endpoint. */
     allowProjectRoot?: boolean;
 }
 

--- a/tools/mods-dev-server/server.d.ts
+++ b/tools/mods-dev-server/server.d.ts
@@ -12,6 +12,9 @@ export interface ServerSettings {
 
     /** Whether or not to open a browser. Defaults to true. */
     open?: boolean;
+
+    /** If the server should expose the modProjectRoot endpoint. */
+    allowProjectRoot?: boolean;
 }
 
 export declare function start(settings: ServerSettings) : http.Server;

--- a/tools/mods-dev-server/server.js
+++ b/tools/mods-dev-server/server.js
@@ -258,6 +258,14 @@ function start(settings = {}) {
             let json = JSON.parse(content);
             declaredExternalResourcesInManifest = json.externalResources || [];
             manifestFiles = [...(json.files || []), json.icon];
+
+            if (json.scripts) {
+                for (const script of json.scripts) {
+                    if (script.file) {
+                        manifestFiles.push(script.file);
+                    }
+                }
+            }
         } catch (err) {}
     }
 

--- a/tools/mods-dev-server/server.js
+++ b/tools/mods-dev-server/server.js
@@ -96,7 +96,7 @@ function start(settings = {}) {
     if (settings.allowProjectRoot) {
         // We need to be able to retrieve the absolute path to the project root to
         // enable source maps when debugging scripts in action mods.
-        app.use("/modProjectRoot", (req, res, next) => {
+        app.use("/spotfire/modProjectRoot", (req, res, next) => {
             res.setHeader("Content-Type", "text/plain; charset=UTF-8");
             res.write(rootDirectoryAbsolutePath);
             res.end();

--- a/tools/mods-dev-server/server.js
+++ b/tools/mods-dev-server/server.js
@@ -52,7 +52,8 @@ const defaultSettings = {
     port: 8090,
     open: true,
     root: ".",
-    path: "/" + manifestName
+    path: "/" + manifestName,
+    allowProjectRoot: false
 };
 
 module.exports.start = start;
@@ -91,6 +92,17 @@ function start(settings = {}) {
     app.use(cacheHeaders);
     app.use(cspHeaders);
     app.use(corsHeaders);
+
+    if (settings.allowProjectRoot) {
+        // We need to be able to retrieve the absolute path to the project root to
+        // enable source maps when debugging scripts in action mods.
+        app.use("/modProjectRoot", (req, res, next) => {
+            res.setHeader("Content-Type", "text/plain; charset=UTF-8");
+            res.write(rootDirectoryAbsolutePath);
+            res.end();
+        });
+    }
+
     app.use(checkIfPartOfManifest);
     app.use(onlyWhenOriginIsSet(injectWebSocketSnippet(settings)));
     app.use(serveStaticFiles);


### PR DESCRIPTION
The development server will require some minor changes to support action mods.

* Action mods will contain script files which are defined outside of the "files" section in the manifest. These files will be defined under the "scripts" property which will host and array of objects where each object specifies a file path via the "file" property. These files should be allowed to be fetched from the development server.
* There needs to be an endpoint where the absolute path of the project root can be retrieved. This is necessary since V8 requires an absolute path to the script file being execute to support source maps. In this PR this endpoint is only enabled when providing the "--allow-project-root true" argument. I'm not sure if we need to put it behind a flag though, I mainly did it to avoid "breaking" the API since someone hay have had a file named modProjectRoot.